### PR TITLE
Update native library dependencies

### DIFF
--- a/native/src/Cargo.toml
+++ b/native/src/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "onionfruit_worker_native"
-version = "0.2.0"
-edition = "2021"
+version = "1.0.1"
+edition = "2024"
 
 [lib]
 name = "onionfruit_worker_native"
@@ -14,5 +14,5 @@ strip = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ipnetwork = { version = "0.20.0", default-features = false }
-rangemap = "1.4.0"
+ipnetwork = "0.21.1"
+rangemap = "1.6.0"


### PR DESCRIPTION
Upgrades to "2024" edition rust, bumps dependencies and resolves warnings:

- usages of `extern "cdecl" ` has been replaced with `extern "C"`
- `no_mangle` macros are wrapped in `unsafe`
- parts of `free_sort_result` have been wrapped in unsafe blocks